### PR TITLE
Undo Joaco change in checkEqualMetamodellingRuleIteration

### DIFF
--- a/src/main/java/org/semanticweb/HermiT/tableau/MetamodellingManager.java
+++ b/src/main/java/org/semanticweb/HermiT/tableau/MetamodellingManager.java
@@ -27,7 +27,6 @@ public final class MetamodellingManager {
         List<OWLClassExpression> node1Classes = MetamodellingAxiomHelper.getMetamodellingClassesByIndividual(this.m_tableau.getNodeToMetaIndividual().get(node1.getNodeID()), this.m_tableau.getPermanentDLOntology());
         if (node0Classes.isEmpty() || node1Classes.isEmpty()) return false;
 
-        boolean wasRuleApplied = false;
         for (OWLClassExpression node0Class : node0Classes) {
             for (OWLClassExpression node1Class : node1Classes) {
                 if (node1Class == node0Class) break;
@@ -36,13 +35,12 @@ public final class MetamodellingManager {
                 boolean isNode0ClassContainedInNode1Class = MetamodellingAxiomHelper.containsSubClassOfAxiom(node1Class, node0Class, this.m_tableau.getPermanentDLOntology());
                 if (!isNode1ClassContainedInNode0Class || !isNode0ClassContainedInNode1Class) {
                     MetamodellingAxiomHelper.addSubClassOfAxioms(node0Class, node1Class, this.m_tableau.getPermanentDLOntology(), this.m_tableau);
-//                    TODO: Checkear que este return esta bien
-//                    No debería de seguir agregando cosas?
-                    wasRuleApplied =  true;
+                    // TODO: Checkear que este return esta bien
+                    return true;
                 }
             }
         }
-        return wasRuleApplied;
+        return false;
     }
 
     public boolean checkInequalityMetamodellingRuleIteration(Node node0, Node node1) {


### PR DESCRIPTION
The reason is that we are not sure about this change so we prefer to leave as it was initially.