### PR TITLE
Fix - Consider null tuples in isTupleActive and retrieveTuple

### DIFF
--- a/src/main/java/org/semanticweb/HermiT/tableau/ExtensionManager.java
+++ b/src/main/java/org/semanticweb/HermiT/tableau/ExtensionManager.java
@@ -46,6 +46,10 @@ implements Serializable {
 
             @Override
             public boolean isTupleActive(Object[] tuple) {
+                if (tuple[1] == null) {
+                    return false;
+                }
+
                 return ((Node)tuple[1]).isActive();
             }
 

--- a/src/main/java/org/semanticweb/HermiT/tableau/TupleTable.java
+++ b/src/main/java/org/semanticweb/HermiT/tableau/TupleTable.java
@@ -55,6 +55,10 @@ implements Serializable {
     }
 
     public void retrieveTuple(Object[] tupleBuffer, int tupleIndex) {
+        if (this.m_pages[tupleIndex / PAGE_SIZE] == null) {
+            return;
+        }
+
         this.m_pages[tupleIndex / PAGE_SIZE].retrieveTuple(tupleIndex % PAGE_SIZE * this.m_arity, tupleBuffer);
     }
 


### PR DESCRIPTION
`isTupleActive` returns `false` in case that the tuple has null values and `retrieveTuple` makes an early return.